### PR TITLE
Support Docusaurus Faster

### DIFF
--- a/docusaurus-plugin-copy.js
+++ b/docusaurus-plugin-copy.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = function(context, opts) {
   const DEFAULT_OPTIONS = {
@@ -23,8 +22,12 @@ module.exports = function(context, opts) {
       return [...patterns];
     },
 
-    configureWebpack() {
+    configureWebpack(_config, _isServer, { currentBundler }) {
       const { context } = options;
+      const CopyPlugin =
+        currentBundler?.name === 'rspack'
+          ? currentBundler.instance.CopyRspackPlugin
+          : require('copy-webpack-plugin');
       return {
         plugins: [
           new CopyPlugin(patterns.map(pattern => {


### PR DESCRIPTION
Rspack used in Docusaurus Faster doesn't support [copy-webpack-plugin](https://rspack.dev/guide/compatibility/plugin).

The idea in this PR has been tested in my derived plugin (thank you for your original work).

https://github.com/tats-u/docusaurus-plugin-copy-katex-assets/blob/b926618f95af2e7abfb94a0b9c65d0df59da9735/packages/%40tats-u/docusaurus-plugin-copy-katex-assets/src/index.ts#L98-L113
